### PR TITLE
Clicking on "Need help" now leads to Fliplet documentation about Login components

### DIFF
--- a/interface.html
+++ b/interface.html
@@ -1,7 +1,7 @@
 <form class="widget-holder form-horizontal">
   <header>
     <p>Configure your SAML2 component</p>
-    <a href="#">Need help?</a>
+    <a href="https://help.fliplet.com/article/181-login-components">Need help?</a>
   </header>
   <div class="form-group">
     <div class="col-sm-4 control-label">


### PR DESCRIPTION
@tonytlwu @squallstar

Issue
Fliplet/fliplet-studio#4959

Description
Added link on "Need help" button.

Backward compatibility
This change is fully backward compatible.