### PR TITLE
PS-1802 Add debug logging to SAML2 login widget

### DIFF
--- a/js/build.js
+++ b/js/build.js
@@ -4,10 +4,14 @@ Fliplet.Widget.instance('sso-saml', function(data) {
   var $error = $('.sso-error-holder');
 
   var buttonLabel = $btn.text();
+  var appId = Fliplet.Env.get('masterAppId');
+  var logPrefix = '[DEBUG] [SAML2 LOGIN] appId: ' + appId;
 
   function init() {
     $confirmation.translate();
     $btn.text(T('widgets.login.saml2.wait')).addClass('disabled');
+
+    console.log(logPrefix, 'init() — checking existing session');
 
     // Load session and prepare cookie
     Fliplet.Session.get().then(function(session) {
@@ -15,6 +19,8 @@ Fliplet.Widget.instance('sso-saml', function(data) {
 
       // User not logged in
       if (!session || !session.accounts) {
+        console.log(logPrefix, 'init() — no session or accounts, showing login button');
+
         return Promise.reject();
       }
 
@@ -22,10 +28,14 @@ Fliplet.Widget.instance('sso-saml', function(data) {
 
       // No SAML2 account found
       if (!saml2Accounts.length) {
+        console.log(logPrefix, 'init() — no saml2 accounts in session, showing login button');
+
         return Promise.reject();
       }
 
       var entry = saml2Accounts[0];
+
+      console.log(logPrefix, 'init() — existing saml2 session found, user:', FlipletLoginSAMLUtils.get(entry, 'user.email'), '— auto-redirecting');
 
       // Update stored user data on retrieved session
       var user = {
@@ -42,6 +52,8 @@ Fliplet.Widget.instance('sso-saml', function(data) {
         firstName: FlipletLoginSAMLUtils.get(entry, 'user.firstName'),
         lastName: FlipletLoginSAMLUtils.get(entry, 'user.lastName')
       }).then(function() {
+        console.log(logPrefix, 'init() — profile set, running sessionValidate hook');
+
         return Fliplet.Hooks.run('sessionValidate', {
           passport: 'saml2',
           userProfile: entry.user
@@ -49,13 +61,17 @@ Fliplet.Widget.instance('sso-saml', function(data) {
       });
     }).then(function() {
       if (typeof data.redirectAction === 'undefined') {
+        console.warn(logPrefix, 'init() — no redirectAction configured');
+
         return;
       }
+
+      console.log(logPrefix, 'init() — sessionValidate passed, navigating to secured page');
 
       return Fliplet.Navigate.to(data.redirectAction);
     }).catch(function(err) {
       $btn.text(buttonLabel).removeClass('disabled');
-      console.error('Could not load the session', err);
+      console.error(logPrefix, 'init() — session check failed or no saml2 account:', err);
 
       if (err) {
         $error.html(Fliplet.parseError(err));
@@ -81,9 +97,12 @@ Fliplet.Widget.instance('sso-saml', function(data) {
         throw new Error('Provider ' + ssoProviderPackageName + ' has not registered on Fliplet.Widget.register with an "authorize()" function.');
       }
 
+      console.log(logPrefix, 'button clicked — starting authorize()');
       $btn.text(T('widgets.login.saml2.wait')).addClass('disabled');
 
       ssoProvider.authorize(data).then(function onAuthorized() {
+        console.log(logPrefix, 'authorize() resolved — showing verifying toast');
+
         return Fliplet.UI.Toast({
           position: 'bottom',
           backdrop: true,
@@ -91,7 +110,11 @@ Fliplet.Widget.instance('sso-saml', function(data) {
           duration: false,
           message: T('widgets.login.saml2.verifying')
         }).then(function(toast) {
+          console.log(logPrefix, 'fetching saml2 passport data');
+
           return Fliplet.Session.passport('saml2').data().then(function(response) {
+            console.log(logPrefix, 'passport data received, user:', response.user && response.user.email);
+
             var user = {
               type: 'saml2',
               organizationId: Fliplet.Env.get('organizationId'),
@@ -106,11 +129,14 @@ Fliplet.Widget.instance('sso-saml', function(data) {
               firstName: response.user.firstName,
               lastName: response.user.lastName
             }).then(function() {
+              console.log(logPrefix, 'profile set, running login hook');
+
               return Fliplet.Hooks.run('login', {
                 passport: 'saml2',
                 userProfile: response.user
               });
             }).then(function() {
+              console.log(logPrefix, 'login hook passed, navigating to secured page');
               toast.dismiss();
 
               $('.sso-confirmation').fadeIn(250, function() {
@@ -124,7 +150,7 @@ Fliplet.Widget.instance('sso-saml', function(data) {
           });
         });
       }).catch(function onError(err) {
-        console.error(err);
+        console.error(logPrefix, 'authorize or post-auth flow FAILED:', err);
         $error.html(err);
         $error.removeClass('hidden');
         $btn.text(buttonLabel).removeClass('disabled');


### PR DESCRIPTION
## Summary
- Add browser console logs to trace the full SAML2 login flow in the login widget
- Covers: init session check, existing saml2 account detection, button click, authorize() resolution, passport data fetch, profile set, `sessionValidate` hook, `login` hook, and navigation to secured page
- All logs prefixed with `[DEBUG] [SAML2 LOGIN] appId: <id>`
- Companion to:
  - fliplet-widget-sso-saml2 PR #44 (SSO component client-side logs)
  - fliplet-api PR #7789 (server-side SAML2 logs)

Together these 3 PRs give full end-to-end visibility:
1. **Login widget**: button click → authorize() → passport data → login hook → navigate
2. **SSO component**: authorize() → popup open → onclose → session check
3. **API**: login redirect → Azure AD callback → assertion → passport storage → DS lookup

## Test plan
- [ ] Deploy widget and trigger SSO login
- [ ] Check browser console for `[DEBUG] [SAML2 LOGIN]` logs at each step
- [ ] Verify init() logs show session state on page load
- [ ] Verify post-auth logs show passport data and hook execution
- [ ] No functional change to the login flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)