### PR TITLE
fix(DEV-1068): add missing redirectAction.page reference for clone remapping

### DIFF
--- a/widget.json
+++ b/widget.json
@@ -5,7 +5,7 @@
   "icon": "img/icon.png",
   "tags": ["type:component", "category:security"],
   "provider_only": false,
-  "references": [],
+  "references": ["redirectAction.page:page"],
   "html_tag": "div",
   "interface": {
     "dependencies": [


### PR DESCRIPTION
## Summary
- Add `redirectAction.page:page` to top-level `references` array in widget.json

The clone process uses `widget.json` references to remap page IDs. This widget stores a page reference via the link provider at `redirectAction.page` but never declared it, causing cloned apps to retain the source app's page ID for SSO redirects (PS-1824).

## Test plan
- [ ] Clone an app with SAML2 login configured with a redirect page
- [ ] Verify the cloned app's SAML2 widget `redirectAction.page` points to the new cloned page

🤖 Generated with [Claude Code](https://claude.com/claude-code)