### PR TITLE
DEV-1208 Hide Basic Authentication option behind collapse toggle

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -28,3 +28,32 @@
   color: #333;
   opacity: 0.5;
 }
+
+.basic-auth-toggle {
+  margin: 15px 0;
+}
+
+.basic-auth-toggle a {
+  color: #00abd1;
+  cursor: pointer;
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.basic-auth-toggle a:hover,
+.basic-auth-toggle a:focus {
+  text-decoration: underline;
+}
+
+.basic-auth-toggle .toggle-chevron {
+  transition: transform 0.2s ease-in-out;
+  margin-right: 4px;
+}
+
+.basic-auth-toggle a.expanded .toggle-chevron {
+  transform: rotate(90deg);
+}
+
+.basic-auth-panel {
+  margin-top: 10px;
+}

--- a/interface.html
+++ b/interface.html
@@ -23,16 +23,22 @@
     </div>
   </div>
   <div id="ssoProvider"></div>
-  <hr />
-  <div class="form-group">
-    <div class="col-sm-4 control-label">
-      <label for="basicAuth">Basic Access Authentication</label>
-    </div>
-    <div class="col-sm-8">
-      <input type="checkbox" id="basicAuth" name="basicAuth" /> Check this if your SAML2 server requires the credentials to be set using "Basic Access Authentication". If you're unsure,
-      leave this unchecked.
+  <div class="basic-auth-toggle">
+    <a role="button" data-toggle="collapse" href="#basicAuthPanel" aria-expanded="false" aria-controls="basicAuthPanel">
+      <i class="fa fa-chevron-right toggle-chevron"></i> <span class="toggle-label">Show Basic Authentication Option</span>
+    </a>
+  </div>
+  <div class="collapse basic-auth-panel" id="basicAuthPanel">
+    <div class="form-group">
+      <div class="col-sm-4 control-label">
+        <label for="basicAuth">Basic Access Authentication</label>
+      </div>
+      <div class="col-sm-8">
+        <input type="checkbox" id="basicAuth" name="basicAuth" /> Check this if your SAML2 server requires the credentials to be set using "Basic Access Authentication". If you're unsure, leave this unchecked.
+      </div>
     </div>
   </div>
+  <hr />
   <h3><small>After login, the user is redirected to a screen</small></h3>
   <div id="redirectAction"></div>
 </form>

--- a/js/interface.js
+++ b/js/interface.js
@@ -6,13 +6,38 @@ Fliplet().then(function() {
 
   data.passportType = 'saml2';
 
-  if (data.basicAuth === true) {
-    $('input[name="basicAuth"]').prop('checked', true);
-  }
-
   $(window).on('resize', Fliplet.Widget.autosize);
 
   checkSecurityRules();
+
+  // Defaults to unchecked — only enable when explicitly saved as true
+  $('[name="basicAuth"]').prop('checked', data.basicAuth === true);
+
+  if (data.basicAuth === true) {
+    $('#basicAuthPanel').addClass('in').attr('aria-expanded', 'true');
+    $('[href="#basicAuthPanel"]')
+      .addClass('expanded')
+      .attr('aria-expanded', 'true')
+      .find('.toggle-label').text('Hide Basic Authentication Option');
+  }
+
+  $('#basicAuthPanel').on('shown.bs.collapse hidden.bs.collapse', function() {
+    Fliplet.Widget.autosize();
+  });
+
+  $('#basicAuthPanel').on('show.bs.collapse', function() {
+    $('[href="#basicAuthPanel"]')
+      .addClass('expanded')
+      .attr('aria-expanded', 'true')
+      .find('.toggle-label').text('Hide Basic Authentication Option');
+  });
+
+  $('#basicAuthPanel').on('hide.bs.collapse', function() {
+    $('[href="#basicAuthPanel"]')
+      .removeClass('expanded')
+      .attr('aria-expanded', 'false')
+      .find('.toggle-label').text('Show Basic Authentication Option');
+  });
 
   var linkProvider = Fliplet.Widget.open('com.fliplet.link', {
     selector: '#redirectAction',
@@ -34,8 +59,8 @@ Fliplet().then(function() {
 
   linkProvider.then(function(res) {
     data.buttonLabel = $('[name="buttonLabel"]').val();
-    data.basicAuth = !!$('input[name="basicAuth"]:checked').length;
     data.redirectAction = res.data;
+    data.basicAuth = !!$('[name="basicAuth"]').prop('checked');
 
     Fliplet.Widget.save(data).then(function() {
       Fliplet.Widget.complete();

--- a/widget.json
+++ b/widget.json
@@ -10,7 +10,8 @@
   "interface": {
     "dependencies": [
       "fliplet-core",
-      "fliplet-studio-ui"
+      "fliplet-studio-ui",
+      "bootstrap"
     ],
     "assets": [
       "css/interface.css",


### PR DESCRIPTION
## Summary
- Move the **Basic Access Authentication** checkbox behind its own "Show / Hide Basic Authentication Option" collapse on the SAML2 login widget settings.
- Auto-expand the panel and flip the label to "Hide..." when `basicAuth` is already saved as true.
- Add `bootstrap` to interface dependencies so Bootstrap's collapse JS is actually loaded (without it, `data-toggle="collapse"` is a no-op).

`basicAuth` runtime ownership stays on this widget exactly as before — it is passed to `ssoProvider.authorize(data)` and ultimately to `Fliplet.Navigate.to`. No data migration, no API change, no impact on live apps or on `navigate.js`.

### Why no migration to the SSO widget?

The original plan moved `basicAuth` into the SSO widget so all advanced settings sat in one panel. That required a one-time data migration on first studio open, looking up the sibling login widget's saved value via the API.

- `Fliplet.Widget.open({ instance: true, data: ... })` POSTs to `/v1/widget-instances/:package/interface`, which the API only exposes as GET — caused a 404 on every studio open.
- Working around it with a direct `Fliplet.API.request` to `/v1/widget-instances` worked but added a network roundtrip every studio session, plus a one-time save with cross-widget data assumptions that required careful SSO/login deploy ordering to avoid UI/runtime drift.

For a UI-only ticket the migration's risk wasn't worth it, so we kept `basicAuth` where it already lives and just hid it behind a collapse.

## Test plan
- [ ] Open SAML2 Login settings on a default app → "Show Basic Authentication Option" link visible, panel collapsed
- [ ] Open settings on an app with `basicAuth: true` already saved → label reads "Hide Basic Authentication Option", panel auto-expanded
- [ ] Expand the panel → label flips to "Hide..."; collapse → label flips back to "Show..."
- [ ] Toggle the checkbox and save → value persists; re-open shows correct state and label
- [ ] Verify the SSO widget's "Change Recommended Settings" toggle still aligns flush-left with this one
- [ ] Verify no regression to live SSO login on web + native, with basicAuth on and off

🤖 Generated with [Claude Code](https://claude.com/claude-code)